### PR TITLE
Remove empty bootcamp home section

### DIFF
--- a/bootcamp/site/en/bootcampHome/index.json
+++ b/bootcamp/site/en/bootcampHome/index.json
@@ -27,12 +27,6 @@
     ]
   },
   "section2": {
-    "title": "",
-    "content": [
-    
-    ]
-  },
-  "section3": {
     "title": "Solutions",
     "content": [
       {
@@ -89,7 +83,7 @@
       }
     ]
   },
-  "section4": {
+  "section3": {
     "title": "Collaborations",
     "content": [
       {

--- a/bootcamp/site/zh-CN/bootcampHome/index.json
+++ b/bootcamp/site/zh-CN/bootcampHome/index.json
@@ -27,12 +27,6 @@
     ]
   },
   "section2": {
-    "title": "部署",
-    "content": [
-      
-    ]
-  },
-  "section3": {
     "title": "应用场景",
     "content": [
       {
@@ -89,7 +83,7 @@
       }
     ]
   },
-  "section4": {
+  "section3": {
     "title": "合作项目",
     "content": [
       {


### PR DESCRIPTION
Removed an empty bootcamp home section that was previously used for 'Deployments' section (curious why those links were removed).