### PR TITLE
Update FieldSchema().md to include the `max_length` property.

### DIFF
--- a/API_Reference/pymilvus/v2.3.x/Schema/FieldSchema().md
+++ b/API_Reference/pymilvus/v2.3.x/Schema/FieldSchema().md
@@ -22,6 +22,8 @@ A FieldSchema object.
 | `is_partition_key`   | Boolean value that indicates if the field is a partition-key field.          |
 | `description`        | Description of the field to create                                           |
 | `default_value`      | Default value of the field. This parameter supports only for scalar fields except array and JSON formats. You cannot specify a default value for a primary key field.                                           |
+| `max_length`        | Must be specified to limit the max length of VARCHAR. The value should be in (0, 65535]|
+
 
 ## Example
 


### PR DESCRIPTION
Since this is a required field for `VARCHAR` datatypes, I thought it made sense to go in the properties table.