### PR TITLE
Update query_iterator.md

### DIFF
--- a/API_Reference/pymilvus/v2.3.x/ORM/Collection/query_iterator.md
+++ b/API_Reference/pymilvus/v2.3.x/ORM/Collection/query_iterator.md
@@ -114,7 +114,7 @@ while True:
     res = iterator.next()
     
     if not res:
-        res.close()
+        iterator.close()
         break
 ```
 


### PR DESCRIPTION
fix for query_iterator example. You can't call close() on an empty list (res).