### PR TITLE
Fix DataType.md typo

### DIFF
--- a/API_Reference/milvus-sdk-node/v2.4.x/Collections/DataType.md
+++ b/API_Reference/milvus-sdk-node/v2.4.x/Collections/DataType.md
@@ -18,7 +18,7 @@ This is an enumeration that provides the following constants.
 
 - Int16 = 3
 
-  Sets the data type to **Int64**.
+  Sets the data type to **Int16**.
 
 - Int32 = 4
 


### PR DESCRIPTION
I'm assuming this is a typo and Int16 doesn't set the datatype to Int64.