### PR TITLE
fix: Add 0xFFFD to the list of unsupported csv delimiters

### DIFF
--- a/API_Reference/pymilvus/v2.4.x/DataImport/Config.md
+++ b/API_Reference/pymilvus/v2.4.x/DataImport/Config.md
@@ -10,7 +10,7 @@ The delimiter of CSV file.
 
 The value must be a string of length 1, which defaults to ```","```.
 
-And the following strings are not allowed: ```"\0"```, ```"\n"```, ```"\r"```, ```"""```.
+And the following strings are not allowed: ```"\0"```, ```"\n"```, ```"\r"```, ```"""```, ```0xFFFD```.
 
 - **nullkey** (*string*)
 


### PR DESCRIPTION
Related milvus pr: https://github.com/milvus-io/milvus/pull/36310