### PR TITLE
Update return type pymilvus vector delete

### DIFF
--- a/API_Reference/pymilvus/v2.4.x/MilvusClient/Vector/delete.md
+++ b/API_Reference/pymilvus/v2.4.x/MilvusClient/Vector/delete.md
@@ -71,7 +71,8 @@ A dictionary contains the number of deleted entities.
 
 ```python
 {
-    "delete_cnt": int
+    "delete_count": int,
+    "cost": int
 }
 ```
 


### PR DESCRIPTION
Noticed this imprecision in during development;
The correct data type is also shown in the examples below (Omitting the `cost` since the return type is an `OmitZeroDict` of course, but the true type will have `cost`)

From: https://github.com/milvus-io/pymilvus/blob/34495134958e89ef7c854d2e31967bb580ab5823/pymilvus/milvus_client/milvus_client.py#L633