### PR TITLE
docs(pymilvus): correct MilvusClient.delete return key to delete_count (#1064)

### DIFF
--- a/API_Reference/pymilvus/v2.5.x/MilvusClient/Vector/delete.md
+++ b/API_Reference/pymilvus/v2.5.x/MilvusClient/Vector/delete.md
@@ -71,7 +71,7 @@ A dictionary contains the number of deleted entities.
 
 ```python
 {
-    "delete_cnt": int
+    "delete_count": int
 }
 ```
 

--- a/API_Reference/pymilvus/v2.6.x/MilvusClient/Vector/delete.md
+++ b/API_Reference/pymilvus/v2.6.x/MilvusClient/Vector/delete.md
@@ -69,7 +69,7 @@ A dictionary contains the number of deleted entities.
 
 ```python
 {
-    "delete_cnt": int
+    "delete_count": int
 }
 ```
 


### PR DESCRIPTION
Fixes #1064. The pymilvus `MilvusClient.delete` API reference for v2.5.x and v2.6.x documented the return shape as `{"delete_cnt": int}`, but the actual SDK returns `{"delete_count": int}`, the issue verified this against the live SDK and the userGuide examples in the same repo (`v2.5.x/.../delete-entities.md:40`, `v2.6.x/.../delete-entities.md:40`) already show `{'delete_count': 2}`.

## Files changed

- `API_Reference/pymilvus/v2.6.x/MilvusClient/Vector/delete.md`
- `API_Reference/pymilvus/v2.5.x/MilvusClient/Vector/delete.md`

Both swap `"delete_cnt"` → `"delete_count"` in the RETURNS dict block.

## Test plan

- [x] Docs-only change in two markdown files; no code or build effect
- [x] Aligns with the value already shown in userGuide examples for both versions