### PR TITLE
Sync Java v2.6.x SDK reference from Feishu

### DIFF
--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Client/ConnectConfig.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Client/ConnectConfig.md
@@ -23,6 +23,7 @@ ConnectConfig.builder()
     .serverPemPath(String serverPemPath)
     .serverName(String serverName)
     .proxyAddress(String proxyAddress)
+    .option(Map<String, String> option)
     .build()
 ```
 
@@ -105,6 +106,10 @@ ConnectConfig.builder()
 - `proxyAddress(String proxyAddress)` -
 
     HTTP proxy address for the gRPC connection. Default: `null`.
+
+- `option(Map<String, String> option)`
+
+    Optional key-value metadata sent to the server during connection initialization.
 
 ## Example
 

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/CollectionSchema/CollectionSchema.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/CollectionSchema/CollectionSchema.md
@@ -1,0 +1,62 @@
+# CollectionSchema
+
+A **CollectionSchema** instance represents the schema of a collection. A schema sketches the structure of a collection.
+
+```java
+io.milvus.v2.service.collection.request.CreateCollectionReq.CollectionSchema
+```
+
+## Constructor
+
+Constructs the schema of a collection by defining fields, data types, and other parameters.
+
+```java
+CreateCollectionReq.CollectionSchema.builder()
+    .fieldSchemaList(List<CreateCollectionReq.FieldSchema>)
+    .build();
+```
+
+**BUILDER METHODS:**
+
+- `fieldSchemaList(List<CreateCollectionReq.FieldSchema>)`
+
+    A list of **[FieldSchema](../FieldSchema.md)** objects that define the fields in the collection schema.
+
+    <div class="alert note">
+    
+    A field schema represents and contains metadata for a single field, while **CollectionSchema** ties together a list of FieldSchema objects to define the full schema.
+
+    </div>
+
+**RETURN TYPE:**
+
+*CollectionSchema*
+
+**RETURNS:**
+
+A **CollectionSchema** object.
+
+**EXCEPTIONS:**
+
+- **MilvusClientExceptions**
+
+    This exception will be raised when any error occurs during this operation.
+
+## Example
+
+```java
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.service.collection.request.AddFieldReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+
+// define a Collection Schema
+CreateCollectionReq.CollectionSchema collectionSchema = client.CreateSchema();
+// add two fileds, id and vector
+collectionSchema.addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).autoID(Boolean.FALSE).description("id").build());
+collectionSchema.addField(AddFieldReq.builder().fieldName("vector").dataType(DataType.FloatVector).dimension(dim).build());
+```
+
+## Methods
+
+The following are the methods of the `CollectionSchema` class:
+

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/DataType.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/DataType.md
@@ -74,7 +74,7 @@ This is an enumeration that provides the following constants.
 
 - SparseFloatVector(104)
 
-      Sets the data type to **Sparse Vector**.
+Sets the data type to **Sparse Vector**.
 
 - Inv8Vector(105)
 

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/DataType.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/DataType.md
@@ -74,7 +74,7 @@ This is an enumeration that provides the following constants.
 
 - SparseFloatVector(104)
 
-Sets the data type to **Sparse Vector**.
+    Sets the data type to **Sparse Vector**.
 
 - Inv8Vector(105)
 

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/Function/BoostRanker.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/Function/BoostRanker.md
@@ -77,7 +77,7 @@ BoostRanker.builder()
 
 **RETURNS:**
 
- A boost ranker instance.
+A boost ranker instance.
 
 ## Examples:
 

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/Function/DecayRanker.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/Function/DecayRanker.md
@@ -79,7 +79,7 @@ DecayRanker.builder()
 
 **RETURNS:**
 
- A decay ranker instance.
+A decay ranker instance.
 
 ## Examples:
 

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/Function/ModelRanker.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/Function/ModelRanker.md
@@ -60,7 +60,7 @@ ModelRanker.builder()
 
 **RETURNS:**
 
- A model ranker instance.
+A model ranker instance.
 
 ## Examples:
 

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/Function/RRFRanker.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/Function/RRFRanker.md
@@ -41,7 +41,7 @@ RRFRanker.builder()
 
 **RETURNS:**
 
- A RRF ranker instance.
+A RRF ranker instance.
 
 ## Examples:
 

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/Function/WeightedRanker.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/Function/WeightedRanker.md
@@ -42,7 +42,7 @@ WeightedRanker.builder()
 
 **RETURNS:**
 
- A weighted ranker instance.
+A weighted ranker instance.
 
 ## Examples:
 

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/ListCollectionsV2.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/ListCollectionsV2.md
@@ -33,7 +33,19 @@ A **ListCollectionsResp** object containing a list of collection names. If there
 
 - **collectionNames** (*List<String>*)
 
+    A list of strings containing the names of all existing collections.
+
 - **collectionInfos** (*List<CollectionInfo>*)
+
+    A list of **CollectionInfo** objects. A **CollectionInfo** object has the following fields:
+
+    - **collectionName** (*String*)
+
+        The name of a collection.
+
+    - **shardNum** (*Integer*)
+
+        The number of shards in the above collection.
 
 **EXCEPTIONS:**
 

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/batchDescribeCollection.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/batchDescribeCollection.md
@@ -12,6 +12,7 @@ public List<DescribeCollectionResp> batchDescribeCollection(BatchDescribeCollect
 batchDescribeCollection(BatchDescribeCollectionReq.builder()
     .databaseName(String databaseName)
     .collectionNames(List<String> collectionNames)
+    .collectionIds(List<Long> collectionIds)
     .build();
 )
 ```
@@ -25,6 +26,10 @@ batchDescribeCollection(BatchDescribeCollectionReq.builder()
 - `collectionNames(List<String> collectionNames)`
 
     The names of the target collections.
+
+- `collectionIds(List<Long> collectionIds)`
+
+    The numeric IDs of the collections to describe. Use this when you need to identify collections by ID instead of name.
 
 **RETURN TYPE:**
 
@@ -40,35 +45,67 @@ A **DescribeCollectionResp** object that contains detailed information about the
 
 - **collectionName** (*String*)
 
+    The name of the current collection.
+
 - **collectionID** (*Long*)
+
+    The ID of the collection.
 
 - **databaseName** (*String*)
 
+    The name of the database to which the current collection belongs.
+
 - **description** (*String*)
+
+    The description of the current collection.
 
 - **numOfPartitions** (*long*)
 
+    The number of partitions in the current collection.
+
 - **fieldNames** (*List\<String\>*)
+
+    A list of fields in the current collection.
 
 - **vectorFieldName** (*List\<String\>*)
 
+    The name of the vector field.
+
 - **primaryFieldName** (*String*)
+
+    The name of the primary field.
 
 - **enableDynamicField** (*Boolean*)
 
+    Whether to use the reserved JSON field **&#36;meta** to save non-schema-defined fields and their values as key-value pairs.
+
 - **autoID** (*Boolean*)
 
-- **collectionSchema** (*CreateCollectionReq.CollectionSchema*)
+    Whether Milvus automatically generates the primary key for the collection.
+
+- **[collectionSchema](CollectionSchema/CollectionSchema.md)** (*CreateCollectionReq.CollectionSchema*)
+
+    The scheme of the collection.
 
 - **createTime** (*Long*)
 
+    The time when the collection was created.
+
 - **createUtcTime** (*Long*) -
+
+    The time when the collection was created in UTC.
 
 - **[consistencyLevel](ConsistencyLevel.md)** (*[ConsistencyLevel](ConsistencyLevel.md)*) -
 
+    The consistency level of the collection.
+
 - **shardsNum** (*Integer*) -
 
+    The number of shards in the collection.
+
 - **properties** (*Map<String, String>*) -
+
+    The properties of the current collection.
 
 **EXCEPTIONS:**
 
@@ -99,4 +136,3 @@ BatchDescribeCollectionReq describeCollectionReq = BatchDescribeCollectionReq.bu
 List<DescribeCollectionResp> batchResp = client.batchDescribeCollection(describeCollectionReq);
 
 ```
-

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/createSchema.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/createSchema.md
@@ -1,0 +1,48 @@
+# createSchema()
+
+This operation creates a collection schema.
+
+```java
+public CreateCollectionReq.CollectionSchema createSchema()
+```
+
+## Request Syntax
+
+```java
+MilvusClientV2.createSchema()
+```
+
+**PARAMETERS:**
+
+None
+
+**RETURN TYPE:**
+
+*CreateCollectionReq.CollectionSchema*
+
+**RETURNS:**
+
+A **CreateCollectionReq.CollectionSchema** object.
+
+## Example
+
+```java
+import io.milvus.v2.client.ConnectConfig;
+import io.milvus.v2.client.MilvusClientV2;
+import io.milvus.v2.common.DataType;
+import io.milvus.v2.service.collection.request.AddFieldReq;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+
+// 1. Set up a client
+ConnectConfig connectConfig = ConnectConfig.builder()
+        .uri("http://localhost:19530")
+        .token("root:Milvus")
+        .build();
+        
+MilvusClientV2 client = new MilvusClientV2(connectConfig);
+
+// 2 Quickly create a collectionSchema
+CreateCollectionReq.CollectionSchema collectionSchema = client.createSchema();
+collectionSchema.addField(AddFieldReq.builder().fieldName("id").dataType(DataType.Int64).isPrimaryKey(Boolean.TRUE).autoID(Boolean.FALSE).description("id").build());
+collectionSchema.addField(AddFieldReq.builder().fieldName("vector").dataType(DataType.FloatVector).dimension(dim).build());
+```

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/describeCollection.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/describeCollection.md
@@ -37,8 +37,6 @@ describeCollection(DescribeCollectionReq.builder()
 
 *DescribeCollectionResp*
 
-A **DescribeCollectionResp** object that contains the collection schema and metadata.
-
 A **DescribeCollectionResp** object that contains detailed information about the specified collection.
 
 **PARAMETERS:**
@@ -105,7 +103,7 @@ A **DescribeCollectionResp** object that contains detailed information about the
 
 - **properties** (*Map<String, String>*) -
 
-    The properties of the current collection. 
+    The properties of the current collection.
 
 **EXCEPTIONS:**
 

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/describeCollection.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/describeCollection.md
@@ -1,6 +1,6 @@
 # describeCollection()
 
-This operation lists detailed information about a specific collection.
+This operation lists detailed information about a specific collection. You can identify the collection by name or by collection ID.
 
 ```java
 public DescribeCollectionResp describeCollection(DescribeCollectionReq request)
@@ -12,6 +12,7 @@ public DescribeCollectionResp describeCollection(DescribeCollectionReq request)
 describeCollection(DescribeCollectionReq.builder()
     .databaseName(String databaseName)
     .collectionName(String collectionName)
+    .collectionId(Long collectionId)
     .build()
 )
 ```
@@ -28,11 +29,15 @@ describeCollection(DescribeCollectionReq.builder()
 
     Setting this to a non-existing collection results in **MilvusException**.
 
-**RETURN TYPE:**
+- `collectionId(Long collectionId)`
+
+    The numeric ID of the collection to describe. Use this when you need to identify the collection by ID instead of name.
+
+**RETURNS:**
 
 *DescribeCollectionResp*
 
-**RETURNS:**
+A **DescribeCollectionResp** object that contains the collection schema and metadata.
 
 A **DescribeCollectionResp** object that contains detailed information about the specified collection.
 
@@ -78,7 +83,7 @@ A **DescribeCollectionResp** object that contains detailed information about the
 
     Whether Milvus automatically generates the primary key for the collection.
 
-- **collectionSchema** (*CreateCollectionReq.CollectionSchema*)
+- **[collectionSchema](CollectionSchema/CollectionSchema.md)** (*CreateCollectionReq.CollectionSchema*)
 
     The scheme of the collection.
 
@@ -104,30 +109,19 @@ A **DescribeCollectionResp** object that contains detailed information about the
 
 **EXCEPTIONS:**
 
-- **MilvusClientExceptions**
+- **MilvusClientException**
 
     This exception will be raised when any error occurs during this operation.
 
 ## Example
 
 ```java
-import io.milvus.v2.client.ConnectConfig;
-import io.milvus.v2.client.MilvusClientV2;
 import io.milvus.v2.service.collection.request.DescribeCollectionReq;
 import io.milvus.v2.service.collection.response.DescribeCollectionResp;
 
-// 1. Set up a client
-ConnectConfig connectConfig = ConnectConfig.builder()
-        .uri("http://localhost:19530")
-        .token("root:Milvus")
-        .build();
-        
-MilvusClientV2 client = new MilvusClientV2(connectConfig);
+DescribeCollectionReq request = DescribeCollectionReq.builder()
+    .collectionName("book_chunks")
+    .build();
 
-// 2. Get the collection detail
-DescribeCollectionReq describeCollectionReq = DescribeCollectionReq.builder()
-        .collectionName("test")
-        .build();
-DescribeCollectionResp describeCollectionResp = client.describeCollection(describeCollectionReq);
-
+DescribeCollectionResp response = client.describeCollection(request);
 ```

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/truncateCollection.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Collections/truncateCollection.md
@@ -1,0 +1,48 @@
+# truncateCollection()
+
+This operation removes all data from a collection while preserving the collection schema, indexes, and aliases.
+
+```java
+client.truncateCollection(TruncateCollectionReq request)
+```
+
+## Request Syntax
+
+```java
+TruncateCollectionReq.builder()
+    .collectionName(String collectionName)
+    .databaseName(String databaseName)
+    .build()
+```
+
+**BUILDER METHODS:**
+
+- `collectionName(String collectionName)` -
+
+    **[REQUIRED]**
+
+    The name of the collection to truncate.
+
+- `databaseName(String databaseName)` -
+
+    The name of the database containing the collection. If not specified, the default database is used.
+
+**RETURNS:**
+
+*void*
+
+**EXCEPTIONS:**
+
+- **MilvusClientException** - The specified collection does not exist or the server is unreachable.
+
+## Example
+
+```java
+import io.milvus.v2.service.collection.request.TruncateCollectionReq;
+
+TruncateCollectionReq req = TruncateCollectionReq.builder()
+    .collectionName("my_collection")
+    .build();
+
+client.truncateCollection(req);
+```

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/BulkImport/BulkImport.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/BulkImport/BulkImport.md
@@ -1,0 +1,12 @@
+# BulkImport
+
+A **BulkImport** instance provides methods for you to manipulate data import jobs.
+
+```java
+io.milvus.bulkwriter.BulkImport
+```
+
+## Constructor
+
+*None*
+

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/VolumeBulkWriter.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/VolumeBulkWriter.md
@@ -1,0 +1,139 @@
+# VolumeBulkWriter
+
+A **VolumeBulkWriter** instance rewrites your raw data to a Zilliz Cloud Volume in a format that Milvus understands.
+
+```java
+io.milvus.bulkwriter.VolumeBulkWriter
+```
+
+## Constructor
+
+Constructs a **VolumeBulkWriter** instance by schema, output path, segment size, and file type.
+
+<div class="alert note">
+
+A **VolumeBulkWriter** object intends to rewrite your raw data to a Zilliz Cloud Volume in a format that Milvus understands.
+
+</div>
+
+```java
+VolumeBulkWriter(VolumeBulkWriterParam bulkWriterParam)
+```
+
+**PARAMETERS:**
+
+- **bulkWriterParam** (*VolumeBulkWriterParam*) -
+
+    A [VolumeBulkWriterParam](VolumeBulkWriter.md) instance.
+
+## VolumeBulkWriterParam
+
+**VolumeBulkWriterParam** allows you to configure properties for your **VolumeBulkWriter** instances in one place so that you can instantiate the **VolumeBulkWriter** class.
+
+```java
+VolumeBulkWriterParam.newBuilder()
+    .withCollectionSchema(CreateCollectionReq.CollectionSchema collectionSchema)
+    .withLocalPath(String localPath)
+    .withChunkSize(long chunkSize)
+    .withFileType(BulkFileType fileType)
+    .withConfig(String key, Object val)
+    .withCloudEndpoint(string cloudEndpoint)
+    .withApiKey(string apiKey)
+    .withVolumeName(string volumeName)
+    .build()
+```
+
+**BUILDER METHODS:**
+
+- `withCollectionSchema(CreateCollectionReq.CollectionSchema collectionSchema)`
+
+    The schema of the target collection that is defined by instantiating **CreateCollectionReq.CollectionSchema**.
+
+- `withLocalPath(String localPath)`
+
+    The path to the directory that is to hold the rewritten data.
+
+- `withChunkSize(long chunkSize)`
+
+    The maximum size of a file segment. While rewriting your raw data, Milvus splits it into segments.
+
+    The value defaults to **536,870,912** in bytes, which is **512 MB**.
+
+    <div class="alert note">
+    
+    The way BulkWriter segments your data varies with the target file type.
+    
+    If the generated file exceeds the specified segment size, BulkWriter creates multiple files and names them in sequence numbers, each no larger than the segment size.
+
+    </div>
+
+- `withFileType(BulkFileType fileType)`
+
+    The type of the output file. Possible options are listed in [BulkFileType](../BulkFileType.md).
+
+- `withConfig(String key, Object val)`
+
+    A dictionary specifying optional configurations for processing CSV files. This parameter applies only when you set `fileType` to `CSV` in `withFileType()`. The dictionary contains the following fields:
+
+    - **sep** (*string*) -
+
+        The delimiter of CSV file. The value must be a string of length 1, which defaults to `","`. The following strings are not allowed: `"\0"`, `"\n"`, `"\r"`, `"""`.
+
+    - **nullkey** (*string*) -
+
+        Special string representing null value. The value defaults to empty string: `""`.
+
+- `withCloudEndpoint(string cloudEndpoint)`
+
+    The Zilliz Cloud public endpoint is always `https:*//*api.cloud.zilliz.com`.
+
+- `withApiKey(string apiKey)`
+
+    A valid Zilliz Cloud API key with sufficient permissions to operate resources related to this operation.
+
+- `withVolumeName(string volumeName)`
+
+    A valid volume name. Ensure that the volume by the specified name exists.
+
+## Example
+
+```java
+import com.google.gson.JsonObject;
+import io.milvus.bulkwriter.VolumeBulkWriter;
+import io.milvus.bulkwriter.VolumeBulkWriterParam;
+import io.milvus.bulkwriter.common.clientenum.BulkFileType;
+import io.milvus.v2.service.collection.request.CreateCollectionReq;
+
+private static void volumeWriter(CreateCollectionReq.CollectionSchema collectionSchema) throws Exception {
+    VolumeBulkWriterParam bulkWriterParam = VolumeBulkWriterParam.newBuilder()
+            .withCollectionSchema(collectionSchema)
+            .withRemotePath("/tmp/bulk_writer")
+            .withFileType(BulkFileType.PARQUET)
+            .withChunkSize(128 * 1024 * 1024)
+            .withCloudEndpoint("https://api.cloud.zilliz.com")
+            .withApiKey("YOUR_API_KEY")
+            .withVolumeName("my_volume")
+            .build();
+
+    try (VolumeBulkWriter volumeBulkWriter = new VolumeBulkWriter(bulkWriterParam)) {
+        // append rows
+        Gson GSON_INSTANCE = new Gson();
+        for (int i = 0; i < 10000; i++) {
+            JsonObject row = new JsonObject();
+            row.addProperty("path", "path_" + i);
+            row.add("vector", GSON_INSTANCE.toJsonTree(GeneratorUtils.genFloatVector(DIM)));
+            row.addProperty("label", "label_" + i);
+
+            volumeBulkWriter.appendRow(row);
+        }
+
+        volumeBulkWriter.commit(false);
+        UploadFilesResult uploadResult = volumeBulkWriter.getVolumeUploadResult();
+        System.out.printf("Data files have been uploaded: %s%n", uploadResult);
+    } catch (Exception e) {
+        System.out.println("Local writer catch exception: " + e);
+        throw e;
+    }
+}
+```
+

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/appendRow.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/appendRow.md
@@ -1,6 +1,6 @@
 # appendRow()
 
-This operation appends a row of data to the LocalBulkWriter buffer. The data will be written to a file when the buffer is full or when `commit()` is called.
+This operation appends a row of data to the VolumeBulkWriter buffer. The data will be written to a file when the buffer is full or when `commit()` is called.
 
 ```java
 public void appendRow(JsonObject rowData) throws IOException, InterruptedException
@@ -33,9 +33,10 @@ public void appendRow(JsonObject rowData) throws IOException, InterruptedExcepti
 ## Example
 
 ```java
-LocalBulkWriter writer = new LocalBulkWriter(config);
+VolumeBulkWriter writer = new VolumeBulkWriter(config);
 JsonObject row = new JsonObject();
 row.addProperty("id", 1L);
 row.add("vector", gson.toJsonTree(new float[]{0.1f, 0.2f, 0.3f}));
 writer.appendRow(row);
 ```
+

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/close.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/close.md
@@ -1,0 +1,28 @@
+# close()
+
+This operation closes the current VolumeBulkWriter instance.
+
+```java
+public void close()
+```
+
+## Request Syntax
+
+```java
+volumeBulkWriter.close()
+```
+
+**PARAMETERS:**
+
+*None*
+
+**RETURNS TYPE:**
+
+*void*
+
+## Example
+
+```java
+volumeBulkWriter.close()
+```
+

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/commit.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/commit.md
@@ -1,0 +1,32 @@
+# commit()
+
+This operation commits the appended data.
+
+```java
+ public void commit(boolean async)
+```
+
+## Request Syntax
+
+```java
+volumeBulkWriter.commit(
+    boolean async
+)
+```
+
+**PARAMETERS:**
+
+- **async** (*boolean*) -
+
+    Whether the commit operation returns immediately after being called.
+
+**RETURN TYPE:**
+
+*void*
+
+## Examples
+
+```java
+volumeBulkWriter.commit(false);
+```
+

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/getBatchFiles.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/getBatchFiles.md
@@ -1,0 +1,28 @@
+# getBatchFiles()
+
+This operation returns a list of files passed to the current VolumeBulkWriter instance.
+
+```java
+public List<List<String>> getBatchFiles()
+```
+
+## Request Syntax
+
+```java
+volumeBulkWriter.getBatchFiles()
+```
+
+**PARAMETERS:**
+
+*None*
+
+**RETURNS TYPE:**
+
+*List\<List\<String>>*
+
+## Example
+
+```java
+List<List<String>> batchFiles = volumeBulkWriter.getBatchFiles();
+```
+

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/getTotalRowCount.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/getTotalRowCount.md
@@ -1,0 +1,27 @@
+# getTotalRowCount()
+
+This operation returns the total number of rows written by this VolumeBulkWriter instance.
+
+```java
+public Long getTotalRowCount()
+```
+
+**RETURNS:**
+
+*Long*
+
+**EXCEPTIONS:**
+
+- **MilvusClientException**
+
+    This exception will be raised when any error occurs during this operation.
+
+## Example
+
+```java
+VolumeBulkWriter writer = new VolumeBulkWriter(config);
+// ... append rows
+Long totalRows = writer.getTotalRowCount();
+System.out.println("Total rows written: " + totalRows);
+```
+

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/getVolumeUploadResult.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/DataImport/VolumeBulkWriter/getVolumeUploadResult.md
@@ -1,0 +1,51 @@
+# getVolumeUploadResult()
+
+This operation retrieves the result of the update to the specified volume.
+
+```java
+public UploadFilesResult getVolumeUploadResult()
+```
+
+**PARAMETERS:**
+
+*None*
+
+**RETURN TYPE:**
+
+*UploadFilesResult*
+
+**RETURNS:**
+
+An UploadFilesResult instance that has the following methods:
+
+- `getVolumeName()`
+
+    Returns the name of the target volume.
+
+- `setVolumeName()`
+
+    Sets the name of the target volume.
+
+- `getPath()`
+
+    Returns the path of the uploaded file to the target volume.
+
+- `setPath()`
+
+    Sets the path of the uploaded file to the target volume.
+
+- `toString()`
+
+    Strigifies the UploadFilesResult instance.
+
+## Example
+
+```java
+VolumeBulkWriter writer = new VolumeBulkWriter(config);
+// ... append rows
+UploadFilesResult result = writer.getVolumeUploadResult();
+
+System.out.println("Target volume: " + result.getVolumeName());
+System.out.println("Target paths: " + result.getPath());
+```
+

--- a/API_Reference/milvus-sdk-java/v2.6.x/v2/Vector/upsert.md
+++ b/API_Reference/milvus-sdk-java/v2.6.x/v2/Vector/upsert.md
@@ -1,6 +1,6 @@
 # upsert()
 
-This operation inserts or updates data in a specific collection.
+This operation inserts new rows into a collection or updates existing rows when their primary keys already exist. You can also use partial updates and field-level operations to update selected fields.
 
 ```java
 public UpsertResp upsert(UpsertReq request)
@@ -15,6 +15,7 @@ upsert(UpsertReq.builder()
     .collectionName(String collectionName)
     .partitionName(String partitionName)
     .partialUpdate(boolean partialUpdate)
+    .fieldOps(List<UpsertReq.FieldPartialUpdateOp> fieldOps)
     .build()
 );
 ```
@@ -39,7 +40,11 @@ upsert(UpsertReq.builder()
 
 - `partialUpdate(boolean partialUpdate)` -
 
-    Whether to allow partial field updates during upsert.
+    Whether to enable partial field updates during upsert. Set this to `true` when you want to update only the primary key and the fields provided in each row. If you use `ARRAY_APPEND` or `ARRAY_REMOVE` in `fieldOps`, the SDK sends the request with partial update semantics automatically.
+
+- `fieldOps(List<UpsertReq.FieldPartialUpdateOp> fieldOps)` -
+
+    Controls how fields in `data` are applied during a partial upsert. For most fields, omit this parameter or use the default `REPLACE` operation to replace the field value carried in the request. For `ARRAY` fields, use `ARRAY_APPEND` to append the request payload to the existing array, or `ARRAY_REMOVE` to remove all existing elements that match the request payload, without first reading and rewriting the full array. Each `FieldPartialUpdateOp` targets one `fieldName`. The value in `data` for that field must match the array `element_type`; after `ARRAY_APPEND`, the final array must not exceed the field `max_capacity`.
 
 **RETURNS:**
 
@@ -51,32 +56,35 @@ An **UpsertResp** object that contains information about the number of inserted 
 
 - **MilvusClientException**
 
-    This exception will be raised when any error occurs during this operation.
+    This exception will be raised when any error occurs during this operation, including invalid field-level operation parameters such as a `null` operation, an empty `fieldName`, or a `null` `opType`.
 
 ## Example
 
 ```java
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import io.milvus.v2.client.ConnectConfig;
 import io.milvus.v2.client.MilvusClientV2;
 import io.milvus.v2.service.vector.request.UpsertReq;
 
-// 1. Set up a client
+import java.util.Arrays;
+import java.util.Collections;
+
+Gson gson = new Gson();
+
+// 1. Set up a client.
 ConnectConfig connectConfig = ConnectConfig.builder()
         .uri("http://localhost:19530")
         .token("root:Milvus")
         .build();
-        
+
 MilvusClientV2 client = new MilvusClientV2(connectConfig);
 
-// 2. Upsert operation
+// 2. Upsert a complete row.
 JsonObject row = new JsonObject();
-List<Float> vectorList = new ArrayList<>();
-vectorList.add(2.0f);
-vectorList.add(3.0f);
-row.add("vector", gson.toJsonTree(vectorList));
 row.addProperty("id", 0L);
-row.addProperty("color", "purple")
+row.add("vector", gson.toJsonTree(Arrays.asList(2.0f, 3.0f)));
+row.addProperty("color", "purple");
 
 UpsertReq upsertReq = UpsertReq.builder()
         .collectionName("test")
@@ -84,4 +92,32 @@ UpsertReq upsertReq = UpsertReq.builder()
         .build();
 client.upsert(upsertReq);
 
+// 3. Partially update selected fields.
+JsonObject partialRow = new JsonObject();
+partialRow.addProperty("id", 0L);
+partialRow.addProperty("color", "green");
+
+UpsertReq partialUpdateReq = UpsertReq.builder()
+        .collectionName("test")
+        .data(Collections.singletonList(partialRow))
+        .partialUpdate(true)
+        .build();
+client.upsert(partialUpdateReq);
+
+// 4. Apply a field-level operation during upsert.
+JsonObject arrayRow = new JsonObject();
+arrayRow.addProperty("id", 0L);
+arrayRow.add("tags", gson.toJsonTree(Arrays.asList("new-tag")));
+
+UpsertReq fieldOpReq = UpsertReq.builder()
+        .collectionName("test")
+        .data(Collections.singletonList(arrayRow))
+        .partialUpdate(true)
+        .fieldOps(Collections.singletonList(
+                UpsertReq.FieldPartialUpdateOp.builder()
+                        .fieldName("tags")
+                        .opType(UpsertReq.FieldPartialUpdateOp.OpType.ARRAY_APPEND)
+                        .build()))
+        .build();
+client.upsert(fieldOpReq);
 ```


### PR DESCRIPTION
## Summary
- Sync Java SDK reference v2.6.x from the updated Feishu docs
- Add new CollectionSchema/createSchema/truncateCollection/BulkImport/VolumeBulkWriter pages
- Update changed Java SDK reference entries including ConnectConfig, batchDescribeCollection, describeCollection, and upsert

## Verification
- node scripts/lark-docs/index.js -c scripts/config.json -m java-v2.6.x --all --skipImageDown
- node scripts/lark-docs/index.js -c scripts/config.json -m java-v2.6.x --dry-run
- npm run check:shared-scripts
- git diff --check

Note: export was run from /Users/liyun/sdk-doc-sync so Feishu credentials from .env were loaded.