### PR TITLE
chore(deps): bump @zilliz/toolkit to 0.2.8 for the heading id fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@babel/preset-react": "^7.24.7",
         "@babel/traverse": "^7.25.6",
         "@mdx-js/mdx": "^3.0.1",
-        "@zilliz/toolkit": "0.2.7",
+        "@zilliz/toolkit": "0.2.8",
         "dotenv": "^16.4.5",
         "gray-matter": "^4.0.3",
         "highlight.js": "^11.10.0",
@@ -606,9 +606,9 @@
       "dev": true
     },
     "node_modules/@zilliz/toolkit": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmmirror.com/@zilliz/toolkit/-/toolkit-0.2.7.tgz",
-      "integrity": "sha512-uV8MZejO+RC1SnT9tfqs+Od9orxrJt1tyWqzGtfMlq+/efsyxVPrV41lv4fWE3NmAdTFPohenXe+zc2A3pg4fQ==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmmirror.com/@zilliz/toolkit/-/toolkit-0.2.8.tgz",
+      "integrity": "sha512-R5402kI8MPJVP24YmBHzABXotUh74rlnuEaZiis9vCpkMvTJXTpsg7q04a3/cZpSTXK8QmOrbobwiWVZkzPT1A==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@babel/preset-react": "^7.24.7",
     "@babel/traverse": "^7.25.6",
     "@mdx-js/mdx": "^3.0.1",
-    "@zilliz/toolkit": "0.2.7",
+    "@zilliz/toolkit": "0.2.8",
     "dotenv": "^16.4.5",
     "gray-matter": "^4.0.3",
     "highlight.js": "^11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -359,10 +359,10 @@
   resolved "https://registry.npmmirror.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@zilliz/toolkit@0.2.7":
-  version "0.2.7"
-  resolved "https://registry.npmmirror.com/@zilliz/toolkit/-/toolkit-0.2.7.tgz"
-  integrity sha512-uV8MZejO+RC1SnT9tfqs+Od9orxrJt1tyWqzGtfMlq+/efsyxVPrV41lv4fWE3NmAdTFPohenXe+zc2A3pg4fQ==
+"@zilliz/toolkit@0.2.8":
+  version "0.2.8"
+  resolved "https://registry.npmmirror.com/@zilliz/toolkit/-/toolkit-0.2.8.tgz"
+  integrity sha512-R5402kI8MPJVP24YmBHzABXotUh74rlnuEaZiis9vCpkMvTJXTpsg7q04a3/cZpSTXK8QmOrbobwiWVZkzPT1A==
 
 acorn-jsx@^5.0.0:
   version "5.3.2"


### PR DESCRIPTION
Fixes milvus-io/milvus.io#2404

## Problem

A heading can carry a version badge, written in the source as:

```md
## Upsert ARRAY fields in merge mode | Milvus 2.6.17+
```

The `| <badge>` part is only a marker — it renders as its own `<span class="beta-tag">`. But the id generator built the id from the **whole raw heading line**, so `generate:en` emitted:

```html
<h2 id="Upsert-ARRAY-fields-in-merge-mode--Milvus-2617+" class="common-anchor-header">
```

The `|` is dropped as a special char while the spaces around it survive as `--`. The source's own links point at `#Upsert-ARRAY-fields-in-merge-mode`, so they match nothing and go nowhere — `v3.0.x/site/en/userGuide/insert-and-delete/upsert-entities.md` lines 37 and 79.

## Fix

`@zilliz/toolkit@0.2.8` ([zilliztech/zilliz.com#4702](https://github.com/zilliztech/zilliz.com/pull/4702)) derives the id from the title alone. The pin here was exact (`"0.2.7"`, no caret), so it could not arrive on its own.

## Verified on the real generation path

Ran `Milvus.md2html` with exactly the options `tools/utils.js` passes (`showAnchor`, `version`, `path`, `betaTag`, `useLatex`) over the actual source file:

| | 0.2.7 | 0.2.8 |
|---|---|---|
| | `Upsert-in-merge-mode--Milvus-v262+` | `Upsert-in-merge-mode` |
| | `Upsert-entities-in-merge-mode--Milvus-v262+` | `Upsert-entities-in-merge-mode` |
| | `Upsert-ARRAY-fields-in-merge-mode--Milvus-2617+` | `Upsert-ARRAY-fields-in-merge-mode` |
| in-doc hash links that resolve | 2 of 3 | **3 of 3** |

Headings without a badge are untouched (`Upsert-StructArray-field-in-merge-mode` is identical either way), and a `|` that resolves to no badge keeps the id it has always had.

## Lockfiles

Both are updated and kept on the registry the rest of each file uses. Neither version of the package has any dependencies, so the change is exactly the one entry in each.

`yarn.lock` was written by yarn itself — I confirmed a real `yarn install` in an isolated checkout reproduces this file byte for byte, rather than letting `npm install` rewrite it (npm syncs `yarn.lock` when present, and its resolution pulled in unrelated entries).

## On merge

`master.yml` runs `yarn generate:en`, commits the regenerated docs and dispatches milvus.io's production build, so merging republishes every doc with the corrected ids.

Links already shared that use the badge-suffixed id keep working: milvus-io/milvus.io#2405 resolves both forms on the client.

## Not covered

`tools/utils.js` has its own copy of `getHeadingIdFromToken` (line 165) with the same bug, used by the `rehypeAnchorHeadingPlugin` on the `.mdx` path. Upgrading the toolkit does not reach it. All 397 `.mdx` files were checked and none has a badged heading, so nothing is broken today — but it is a latent duplicate worth folding back into the toolkit separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UTdbpaNHcbQRjzXeWSKUmf