### PR TITLE
[Docs][Python SDK] Fix query group-by field types

### DIFF
--- a/API_Reference/pymilvus/v3.0.x/MilvusClient/Vector/query.md
+++ b/API_Reference/pymilvus/v3.0.x/MilvusClient/Vector/query.md
@@ -141,15 +141,15 @@ query(
 
         A list of scalar fields to group the query results by. When set, `query()` returns one row per unique combination of the specified field values, and any aggregation expressions in `output_fields` (`count(*)`, `count(<f>)`, `min(<f>)`, `max(<f>)`, `sum(<f>)`, `avg(<f>)`) are computed per group.
 
-        Supported field types: INT8, INT16, INT32, INT64, FLOAT, DOUBLE, VARCHAR, and TIMESTAMPTZ. Grouping by vector, JSON, or Array fields returns an error.
-
-        Aggregation type rules:
-
-        - `sum` and `avg` are numeric only. Applying them to a `VarChar` field returns an error.
-
-        - `sum(int*)` returns `INT64`; `sum(float|double)` returns `DOUBLE`; `avg(...)` always returns `DOUBLE`; `count(...)` returns `INT64`; `min`/`max` preserve the column type.
+        Supported grouping-key field types: `INT8`, `INT16`, `INT32`, `INT64`, `VARCHAR`, and `TIMESTAMPTZ`. Grouping by `FLOAT`, `DOUBLE`, vector, `JSON`, or `ARRAY` fields returns an error.
 
         You can combine `group_by_fields` with `limit` to cap the number of groups returned.
+
+        Aggregation input type rules:
+
+        - `sum` and `avg` accept only numeric fields, including `FLOAT` and `DOUBLE`. Applying either function to a `VARCHAR` field returns an error.
+
+        - `sum` returns `INT64` for integer inputs and `DOUBLE` for `FLOAT` or `DOUBLE` inputs. `avg` always returns `DOUBLE`; `count` returns `INT64`; and `min` and `max` preserve the field type.
 
 **RETURN TYPE:**
 


### PR DESCRIPTION
## Summary

- Correct the Python `MilvusClient.query()` reference so `group_by_fields` lists only supported grouping-key types: `INT8`, `INT16`, `INT32`, `INT64`, `VARCHAR`, and `TIMESTAMPTZ`.
- Explicitly state that `FLOAT` and `DOUBLE` are rejected as grouping keys.
- Keep `FLOAT` and `DOUBLE` documented as valid numeric aggregation inputs for `sum`, `avg`, `min`, and `max`.

## Validation

- `git diff --check upstream/master...HEAD`
- Confirmed the PR changes exactly one file: `API_Reference/pymilvus/v3.0.x/MilvusClient/Vector/query.md`
- Confirmed the updated text separates grouping-key types from aggregation input types.
- Documentation-only change; no runtime tests were needed.

## Evidence

- [Server group-by type validation](https://github.com/milvus-io/milvus/blob/master/internal/proxy/task_query.go#L1199-L1219)
- [Python E2E coverage for rejected FLOAT and DOUBLE group keys](https://github.com/milvus-io/milvus/blob/master/tests/python_client/testcases/test_query_aggregation.py#L1225-L1272)