### PR TITLE
docs: clarify search iterator offset support

### DIFF
--- a/API_Reference/pymilvus/v2.6.x/MilvusClient/Vector/search_iterator.md
+++ b/API_Reference/pymilvus/v2.6.x/MilvusClient/Vector/search_iterator.md
@@ -58,9 +58,7 @@ search_iterator(
 
     The total number of entities to return.
 
-    You can use this parameter in combination with **offset** in **param** to enable pagination.
-
-    The sum of this value and **offset** in **param** should be less than 16,384. 
+    The `offset` parameter is not supported by this operation.
 
 - **output_fields** (l*ist[str]*) -
 
@@ -121,14 +119,6 @@ search_iterator(
     The number of decimal places for distance values. The default value is -1, which indicates that no rounding is applied.
 
 - **kwargs** -
-
-    - **offset** (int) -
-
-        The number of records to skip in the search result. 
-
-        You can use this parameter in combination with `limit` to enable pagination.
-
-        The sum of this value and `limit` should be less than 16,384. 
 
     - **round_decimal** (int) -
 
@@ -218,4 +208,3 @@ while True:
     for hit in result:
         results.append(hit.to_dict())
 ```
-

--- a/API_Reference/pymilvus/v3.0.x/MilvusClient/Vector/search_iterator.md
+++ b/API_Reference/pymilvus/v3.0.x/MilvusClient/Vector/search_iterator.md
@@ -58,9 +58,7 @@ search_iterator(
 
     The total number of entities to return.
 
-    You can use this parameter in combination with **offset** in **param** to enable pagination.
-
-    The sum of this value and **offset** in **param** should be less than 16,384. 
+    The `offset` parameter is not supported by this operation.
 
 - **output_fields** (l*ist[str]*) -
 
@@ -121,14 +119,6 @@ search_iterator(
     The number of decimal places for distance values. The default value is -1, which indicates that no rounding is applied.
 
 - **kwargs** -
-
-    - **offset** (int) -
-
-        The number of records to skip in the search result. 
-
-        You can use this parameter in combination with `limit` to enable pagination.
-
-        The sum of this value and `limit` should be less than 16,384. 
 
     - **round_decimal** (int) -
 
@@ -218,4 +208,3 @@ while True:
     for hit in result:
         results.append(hit.to_dict())
 ```
-


### PR DESCRIPTION
## What changed

- Remove the incorrect `offset` pagination guidance from `search_iterator()`.
- Explicitly state that `offset` is not supported.
- Update the PyMilvus v2.6.x and v3.0.x API reference pages.

## Why

PyMilvus rejects a non-zero `offset` for search iterators, while the API reference currently documents it as supported.

This PR intentionally updates documentation only. Parameter-validation consistency remains with the assignee of the Milvus issue.

Related to https://github.com/milvus-io/milvus/issues/53212