### PR TITLE
Update milvus-sdk-java docs to v3.0.9

### DIFF
--- a/API_Reference/milvus-sdk-java/v3.0.x/About.md
+++ b/API_Reference/milvus-sdk-java/v3.0.x/About.md
@@ -43,7 +43,7 @@ Milvus Java SDK is an open-source project and its source code is hosted on [GitH
     </tr>
     <tr>
         <td>3.0.x</td>
-        <td>3.0.5</td>
+        <td>3.0.9</td>
     </tr>
 </table>
 
@@ -57,20 +57,20 @@ You can use **[Apache Maven](https://maven.apache.org/install.html)** or **[Grad
  <dependency>
      <groupId>io.milvus</groupId>
      <artifactId>milvus-sdk-java</artifactId>
-     <version>3.0.5</version>
+     <version>3.0.9</version>
  </dependency>
 ```
 
 - Gradle/Groovy
 
 ```plaintext
-implementation 'io.milvus:milvus-sdk-java:3.0.5'
+implementation 'io.milvus:milvus-sdk-java:3.0.9'
 ```
 
 - Gradle/Kotlin
 
 ```sql
-implementation("io.milvus:milvus-sdk-java:3.0.5")
+implementation("io.milvus:milvus-sdk-java:3.0.9")
 ```
 
 Since v2.5.2, Milvus Java SDK has been split into two packages: **milvus-sdk-java** and **milvus-sdk-java-bulkwriter**. If you do not need BulkWriter, ignore the **milvus-sdk-java-bulkwriter** package. To use BulkWriter, import the **milvus-sdk-java-bulkwriter** as follows:
@@ -79,20 +79,20 @@ Since v2.5.2, Milvus Java SDK has been split into two packages: **milvus-sdk-jav
  <dependency>
      <groupId>io.milvus</groupId>
      <artifactId>milvus-sdk-java-bulkwriter</artifactId>
-     <version>3.0.5</version>
+     <version>3.0.9</version>
  </dependency>
 ```
 
 - Gradle/Groovy
 
 ```plaintext
-implementation 'io.milvus:milvus-sdk-java-bulkwriter:3.0.5'
+implementation 'io.milvus:milvus-sdk-java-bulkwriter:3.0.9'
 ```
 
 - Gradle/Kotlin
 
 ```sql
-implementation("io.milvus:milvus-sdk-java-bulkwriter:3.0.5")
+implementation("io.milvus:milvus-sdk-java-bulkwriter:3.0.9")
 ```
 
 ## **Contributing**

--- a/API_Reference/milvus-sdk-java/v3.0.x/v2/Authentication/grantPrivilege.md
+++ b/API_Reference/milvus-sdk-java/v3.0.x/v2/Authentication/grantPrivilege.md
@@ -24,6 +24,10 @@ grantPrivilege(GrantPrivilegeReq.builder()
 
     The name of the role to assign privileges to.
 
+- `dbName(String dbName)`
+
+    The name of the database the privilege applies to. Since v3.0.9.
+
 - `objectType(String objectType)`
 
     The type of the object for which the privilege is being assigned.

--- a/API_Reference/milvus-sdk-java/v3.0.x/v2/Management/IndexType.md
+++ b/API_Reference/milvus-sdk-java/v3.0.x/v2/Management/IndexType.md
@@ -92,6 +92,10 @@ Sets the index type to TRIE. This applies to VarChar fields only.
 
 Sets the index type to NGRAM. This applies to VarChar fields and JSON Path indexes.
 
+### FMINDEX
+
+Sets the index type to FMINDEX. This applies to VarChar fields only. Answers anchored LIKE (prefix/infix/suffix) queries with exact byte-level matching and no candidate recheck.
+
 ### RTREE
 
 Sets the index type to RTREE. This applies to geometry fields only.

--- a/API_Reference/milvus-sdk-java/v3.0.x/v2/Management/compact.md
+++ b/API_Reference/milvus-sdk-java/v3.0.x/v2/Management/compact.md
@@ -36,6 +36,14 @@ compact(CompactReq.builder()
 
     Whether to request L0 compaction. Defaults to `Boolean.FALSE` and is independent from clustering compaction.
 
+- `targetSize(Long targetSize)`
+
+    The target segment size in `targetSizeUnit`. `null` uses the server default.
+
+- `targetSizeUnit(String targetSizeUnit)`
+
+    The unit for `targetSize`, defaulting to `"mb"`. Since v3.0.9.
+
 **RETURNS:**
 
 *CompactResp*

--- a/API_Reference/milvus-sdk-java/v3.0.x/v2/Vector/delete.md
+++ b/API_Reference/milvus-sdk-java/v3.0.x/v2/Vector/delete.md
@@ -46,6 +46,10 @@ delete(DeleteReq.builder()
 
     A map of template variable values for parameterized filters.
 
+- `consistencyLevel(ConsistencyLevel consistencyLevel)`
+
+    The consistency level for the delete operation. Since v3.0.9.
+
 **RETURNS:**
 
 *DeleteResp*

--- a/API_Reference/milvus-sdk-java/v3.0.x/v2/Vector/get.md
+++ b/API_Reference/milvus-sdk-java/v3.0.x/v2/Vector/get.md
@@ -6,6 +6,12 @@ This operation gets specific entities by their IDs.
 public GetResp get(GetReq request)
 ```
 
+An asynchronous variant is also available:
+
+```java
+public CompletableFuture<GetResp> getAsync(GetReq request)
+```
+
 ## Request Syntax
 
 ```java
@@ -32,6 +38,10 @@ get(GetReq.builder()
 - `partitionName(String partitionName)`
 
     The name of a partition.
+
+- `partitionNames(List<String> partitionNames)`
+
+    A list of partition names to query. Since v3.0.9.
 
 - `ids(List<Object> ids)`
 

--- a/API_Reference/milvus-sdk-java/v3.0.x/v2/Vector/hybridSearch.md
+++ b/API_Reference/milvus-sdk-java/v3.0.x/v2/Vector/hybridSearch.md
@@ -6,6 +6,12 @@ This operation performs multi-vector search on a collection and returns search r
 public SearchResp hybridSearch(HybridSearchReq request)
 ```
 
+An asynchronous variant is also available:
+
+```java
+public CompletableFuture<SearchResp> hybridSearchAsync(HybridSearchReq request)
+```
+
 ## Request Syntax
 
 ```java
@@ -118,6 +124,8 @@ searchRequests.add(AnnSearchReq.builder()
         .vectorFieldName("float_vector")
         .vectors(floatVectors)
         .params("{\"nprobe\": 10}")
+        .expr(expr)      // filter expression, since v3.0.9
+        .topK(topK)      // candidates requested per ANN search, since v3.0.9
         .limit(10)
         .build());
 searchRequests.add(AnnSearchReq.builder()

--- a/API_Reference/milvus-sdk-java/v3.0.x/v2/Vector/query.md
+++ b/API_Reference/milvus-sdk-java/v3.0.x/v2/Vector/query.md
@@ -6,6 +6,12 @@ Queries entities by primary key or filter, with optional ordering through `order
 public QueryResp query(QueryReq request)
 ```
 
+An asynchronous variant is also available:
+
+```java
+public CompletableFuture<QueryResp> queryAsync(QueryReq request)
+```
+
 ## Request Syntax
 
 ```java
@@ -111,6 +117,8 @@ QueryReq.builder()
 *QueryResp*
 
 Contains query rows ordered according to orderByFields when provided.
+
+For struct-array element-level queries (filter expressions using `element_filter`), each result carries an `elementOffset` — the index of the matched element within the struct-array field. Since v3.0.8.
 
 **EXCEPTIONS:**
 

--- a/API_Reference/milvus-sdk-java/v3.0.x/v2/Vector/queryIterator.md
+++ b/API_Reference/milvus-sdk-java/v3.0.x/v2/Vector/queryIterator.md
@@ -83,6 +83,10 @@ queryIterator(QueryIteratorReq.builder()
 
     A map of template variable values for parameterized filters.
 
+- `cursor(QueryIteratorCursor cursor)`
+
+    A cursor used to resume iteration from a previous position. Since v3.0.9.
+
 **RETURNS:**
 
 *QueryIterator*

--- a/API_Reference/milvus-sdk-java/v3.0.x/v2/Vector/search.md
+++ b/API_Reference/milvus-sdk-java/v3.0.x/v2/Vector/search.md
@@ -6,6 +6,12 @@ Performs vector search with optional result ordering, aggregation requests and b
 public SearchResp search(SearchReq request)
 ```
 
+An asynchronous variant is also available:
+
+```java
+public CompletableFuture<SearchResp> searchAsync(SearchReq request)
+```
+
 ## Request Syntax
 
 ```java
@@ -94,6 +100,10 @@ SearchReq.builder()
 
     The number of nearest candidates requested from the server.
 
+- `metricType(IndexParam.MetricType metricType)`
+
+    The metric type used for the search, overriding the one defined on the index.
+
 - `filter(String filter)`
 
     A scalar filtering expression.
@@ -165,6 +175,14 @@ SearchReq.builder()
 - `functionScore(FunctionScore functionScore)`
 
     The scoring functions applied to the search results.
+
+- `ranker(CreateCollectionReq.Function ranker)`
+
+    The ranker (e.g. `RRFRanker`, `WeightedRanker`) used to fuse results from multiple vector fields in a hybrid search.
+
+- `functionChains(List<FunctionChain> functionChains)`
+
+    Function chains applied to the query input before vectorization. Since v3.0.9.
 
 - `filterTemplateValues(Map<String, Object> filterTemplateValues)`
 


### PR DESCRIPTION
- Bump About.md version pins to v3.0.9 (compat table + Maven/Gradle for sdk and bulkwriter)
- Add metricType/ranker to Vector/search.md (pre-existing omissions)
- Add functionChains to Vector/search.md (new in v3.0.9)